### PR TITLE
wrong answers container in results template

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,9 +160,12 @@
           Knowledge rank: <span data-bind="results-rank" />
         </h3>
         <h4 data-bind="visible: resultsPercent() < 100">Missed questions</h4>
-        <div class="missed-questions-container">
-          <p>Question</p>
-          <p>Answer:</p>
+        <div class="missed-questions-container" data-bind="foreach: questionsArray">
+          <div class="individual-missed-question" data-bind="visible: !$data.isCorrect">
+            <div class="question"><pre data-bind="text: $data.question"></pre></div>
+            <p>Your Answer: <span class="answers"><pre data-bind="text: 'todo: fix'"></pre></span></p>
+            <p>Correct Answer: <span class="answers"><pre data-bind="text: $data.answers()[$data.correctAnswerIndex]"></pre></span></p>
+          </div>
         </div>
         <button class="btn btn-secondary" id="restart-button" data-bind="click: restartGame">
           Try Again

--- a/js/questions-answers.js
+++ b/js/questions-answers.js
@@ -77,11 +77,11 @@ function getAllQuestionsAndAnswers() {
       correctAnswerIndex: 1
     },
     {
-      question:
-        "What is the proper way to bring an external" +
-        "javascript file into a different" +
-        "javascript file when using the debugger in" +
-        "VSCode?",
+      question: `
+        What is the proper way to bring an external javascript file
+        into a different javascript file when using the debugger in
+        VSCode?
+        `,
       answers: [
         "const externalLibrary = module.imports(‘jquery.min.js’);",
         "const externalLibrary = module.require(‘jquery.min.js’);",
@@ -91,9 +91,10 @@ function getAllQuestionsAndAnswers() {
       correctAnswerIndex: 3
     },
     {
-      question:
-        "What is the correct way to alter the text" +
-        "inside the following html element?",
+      question: `
+        What is the correct way to alter the text
+        inside the following html element?
+        `,
       answers: [
         "document.getElement(‘container’).innerHTML = ‘This is the new text’;",
         "document.queryId(‘container’).innerHTML = ‘This is the new text’;",
@@ -106,7 +107,8 @@ function getAllQuestionsAndAnswers() {
       question: "Which of these best describes the “Execution Context”?",
       answers: [
         "A wrapper that helps to manage the code that is currently running",
-        "A wrapper that helps to manage ALL of your code, not just the code that is currently running",
+        `A wrapper that helps to manage ALL of your code, not just the
+        code that is currently running`,
         "Where something sits physically in the code that you write",
         "Where your code sits in memory"
       ],
@@ -137,16 +139,16 @@ function getAllQuestionsAndAnswers() {
     `,
       answers: [
         "It returns the value",
-        "It will always return 2",
-        "It will always return 1",
-        "It will return 1 if val is true, otherwise, it will return 2"
+        "It will always return js",
+        "It will always return javascript",
+        "It will return js if val is true, otherwise, it will return javascript"
       ],
       correctAnswerIndex: 3
     },
     {
-      question: `Which operator matches this definition: “a strict equality"
-        "operator that returns true when two operands have the same value"
-        "without coercion.“`,
+      question: `Which operator matches this definition: “a strict equality
+        operator that returns true when two operands have the same
+        value without coercion.“`,
       answers: ["===", "==", "+=", "-="],
       correctAnswerIndex: 0
     },
@@ -180,7 +182,7 @@ function getAllQuestionsAndAnswers() {
     {
       question: `
     What index number is “Red” in the following array?
-    Var color = [“Red”, “Blue”, “Green”];
+    var color = [“Red”, “Blue”, “Green”];
     `,
       answers: ["0", "1", "2", "3"],
       correctAnswerIndex: 0
@@ -219,9 +221,9 @@ function getAllQuestionsAndAnswers() {
       correctAnswerIndex: 2
     },
     {
-      question:
-        "What type of object do other objects inherit properties" +
-        "and methods from?",
+      question: `What type of object do other objects inherit properties
+        and methods from?
+        `,
       answers: ["Prototype", "Native", "Host", "User-Defined"],
       correctAnswerIndex: 0
     },

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -9,7 +9,7 @@ html {
 
 body {
   width: 100%;
-  background-color: #80e5fe!important;
+  background-color: #80e5fe !important;
 }
 
 .header {
@@ -17,7 +17,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  height: 180px;
+  height: 100px;
   width: 100%;
   background-color: black;
   color: #fedc3d;
@@ -230,7 +230,7 @@ body {
 }
 
 .missed-questions-container {
-  width: 80%;
+  width: 95%;
   height: 238px;
   overflow-y: scroll;
   background: #fff;


### PR DESCRIPTION
Fixes #21 

added foreach loop to the results template in the main html. It only creates a wrong answer div if the object in the loop is marked as incorrect, and if so, outputs the question, the original answer (need to go back and finish this), and the correct answer